### PR TITLE
Fix BGMService to enable background music playback

### DIFF
--- a/app/src/main/java/com/wutongyu/mannyburger/BGMService.java
+++ b/app/src/main/java/com/wutongyu/mannyburger/BGMService.java
@@ -98,7 +98,9 @@ public class BGMService extends Service {
                 AudioManager.STREAM_MUSIC,
                 AudioManager.AUDIOFOCUS_GAIN) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
             startForeground(NOTIFICATION_ID, createNotification());
-            if (!isPlaying) {
+            if (intent != null && "com.wutongyu.mannyburger.PLAY_PAUSE".equals(intent.getAction())) {
+                handlePlayPauseAction();
+            } else if (!isPlaying) {
                 playMusic();
             }
         }
@@ -132,6 +134,14 @@ public class BGMService extends Service {
             mediaPlayer.pause();
             isPlaying = false;
             updateNotification(false);
+        }
+    }
+
+    private void handlePlayPauseAction() {
+        if (isPlaying) {
+            pauseMusic();
+        } else {
+            playMusic();
         }
     }
 

--- a/app/src/main/java/com/wutongyu/mannyburger/NotificationReceiver.java
+++ b/app/src/main/java/com/wutongyu/mannyburger/NotificationReceiver.java
@@ -10,11 +10,7 @@ public class NotificationReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         if ("com.wutongyu.mannyburger.PLAY_PAUSE".equals(intent.getAction())) {
             Intent serviceIntent = new Intent(context, BGMService.class);
-            if (BGMService.isMediaPlayerPlaying()) {
-                serviceIntent.putExtra("action", "pause");
-            } else {
-                serviceIntent.putExtra("action", "play");
-            }
+            serviceIntent.setAction("com.wutongyu.mannyburger.PLAY_PAUSE");
             context.startService(serviceIntent);
         }
     }


### PR DESCRIPTION
Add functionality to handle play/pause action from the notification in BGMService and NotificationReceiver.

* **BGMService.java**
  - Modify `onStartCommand` method to handle the play/pause action from the notification.
  - Add `handlePlayPauseAction` method to toggle between play and pause states.
  
* **NotificationReceiver.java**
  - Modify `onReceive` method to handle the play/pause action from the notification by setting the appropriate action in the intent.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Steve5wutongyu6/MannyBurger/pull/1?shareId=1ad7da53-9194-42e3-aff6-07e6d67f9691).